### PR TITLE
Simplify Dragonframe recipes

### DIFF
--- a/Dragonframe/Dragonframe3.download.recipe
+++ b/Dragonframe/Dragonframe3.download.recipe
@@ -12,6 +12,8 @@
         <string>Dragonframe 3</string>
         <key>CHECK_PAGE_URL</key>
         <string>https://www.dragonframe.com/downloads</string>
+        <key>CHECK_PAGE_PATTERN</key>
+        <string>(?P&lt;url&gt;http:\/\/www\.dragonframe.com\/download\/Dragonframe_(?P&lt;version&gt;3.[\d.]+)\.pkg)</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
@@ -26,10 +28,8 @@
             <dict>
                 <key>url</key>
                 <string>%CHECK_PAGE_URL%</string>
-                <key>result_output_var_name</key>
-                <string>url</string>
                 <key>re_pattern</key>
-                <string>Dragonframe_3.*?\.pkg</string>
+                <string>%CHECK_PAGE_PATTERN%</string>
                 <key>re_flags</key>
                 <array>
                     <string>IGNORECASE</string>
@@ -46,8 +46,10 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.pkg</string>
                 <key>url</key>
-                <string>https://www.dragonframe.com/download/%url%</string>
+                <string>%url%</string>
             </dict>
         </dict>
         <dict>

--- a/Dragonframe/Dragonframe3.pkg.recipe
+++ b/Dragonframe/Dragonframe3.pkg.recipe
@@ -11,70 +11,11 @@ into a package</string>
     <dict>
         <key>NAME</key>
         <string>Dragonframe 3</string>
-        <key>CHECK_PAGE_URL</key>
-        <string>https://www.dragonframe.com/downloads</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.amsysuk-recipes.download.Dragonframe3</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCopier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame3.pkg</string>
-                <key>source_pkg</key>
-                <string>%pathname%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/expanded</string>
-                <key>flat_pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame3.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/expanded/DragonFrame.pkg/Payload</string>
-            </dict>
-        </dict>
-         <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Applications/Dragonframe/Dragonframe.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame3.pkg</string>
-                </array>
-            </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>PkgCopier</string>

--- a/Dragonframe/Dragonframe4.download.recipe
+++ b/Dragonframe/Dragonframe4.download.recipe
@@ -12,6 +12,7 @@
         <string>Dragonframe 4</string>
         <key>CHECK_PAGE_URL</key>
         <string>https://www.dragonframe.com/downloads</string>
+        <string>(?P&lt;url&gt;http:\/\/www\.dragonframe.com\/download\/Dragonframe_(?P&lt;version&gt;3.[\d.]+)\.pkg)</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
@@ -26,10 +27,8 @@
             <dict>
                 <key>url</key>
                 <string>%CHECK_PAGE_URL%</string>
-                <key>result_output_var_name</key>
-                <string>url</string>
                 <key>re_pattern</key>
-                <string>Dragonframe_4.*?\.pkg</string>
+                <string>%CHECK_PAGE_PATTERN%</string>
                 <key>re_flags</key>
                 <array>
                     <string>IGNORECASE</string>
@@ -46,8 +45,10 @@
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.pkg</string>
                 <key>url</key>
-                <string>https://www.dragonframe.com/download/%url%</string>
+                <string>%url%</string>
             </dict>
         </dict>
         <dict>

--- a/Dragonframe/Dragonframe4.download.recipe
+++ b/Dragonframe/Dragonframe4.download.recipe
@@ -12,7 +12,7 @@
         <string>Dragonframe 4</string>
         <key>CHECK_PAGE_URL</key>
         <string>https://www.dragonframe.com/downloads</string>
-        <string>(?P&lt;url&gt;http:\/\/www\.dragonframe.com\/download\/Dragonframe_(?P&lt;version&gt;3.[\d.]+)\.pkg)</string>
+        <string>(?P&lt;url&gt;http:\/\/www\.dragonframe.com\/download\/Dragonframe_(?P&lt;version&gt;4.[\d.]+)\.pkg)</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>

--- a/Dragonframe/Dragonframe4.pkg.recipe
+++ b/Dragonframe/Dragonframe4.pkg.recipe
@@ -11,72 +11,11 @@ package</string>
     <dict>
         <key>NAME</key>
         <string>Dragonframe 4</string>
-        <key>CHECK_PAGE_URL</key>
-        <string>https://www.dragonframe.com/downloads</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.amsysuk-recipes.download.Dragonframe4</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame4.pkg</string>
-                <key>source_path</key>
-                <string>%pathname%</string>
-                <key>overwrite</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/expanded</string>
-                <key>flat_pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame4.pkg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/expanded/DragonFrame 4.pkg/Payload</string>
-            </dict>
-        </dict>
-         <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Applications/Dragonframe 4/Dragonframe 4.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame4.pkg</string>
-                </array>
-            </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>PkgCopier</string>


### PR DESCRIPTION
I created my own Dragonframe recipes some time ago and was looking to create my own autopkg recipe repo, but hoped to merge what I'd done with these already available recipes to avoid duplication.

Rather than force a full unpack of the PKG in order to get the version number, I used regex to collect both the full url and version in the download recipe to avoid these steps in the PKG recipe altogether.