### PR TITLE
Update Opera.pkg.recipe

### DIFF
--- a/Opera/Opera.pkg.recipe
+++ b/Opera/Opera.pkg.recipe
@@ -25,7 +25,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Opera.app</string>
 				<key>requirement</key>
-				<string>identifier "com.operasoftware.Opera" and certificate leaf = H"261cd515406974afa19778f62e5d916ec977ebf4"</string>
+				<string>identifier "com.operasoftware.Opera" and certificate leaf = H"cdf1c39967986616b6cd64c6bd04833a9cb7450d"</string>
 			</dict>
 		</dict>
         <dict>


### PR DESCRIPTION
I was getting "Error in com.github.amsysuk-recipes.pkg.opera: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value." errors, updating the certificate leaf appears to resolve this.