### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Adobe/PhoneGapDesktop.download.recipe
+++ b/Adobe/PhoneGapDesktop.download.recipe
@@ -46,7 +46,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/PhoneGapDesktop.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/PhoneGapDesktop.dmg/PhoneGap.app</string>
 				<key>requires</key>
                 <string>identifier "com.electron.phonegap" and anchor apple generic and certificate leaf[subject.CN] = "Mac Developer: Herman Wong (M6QFED29S9)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
 			</dict>

--- a/Amazon/AmazonChime.download.recipe
+++ b/Amazon/AmazonChime.download.recipe
@@ -38,7 +38,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Amazon Chime.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.amazon.Amazon-Chime" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "94KV3E626L")</string>
             </dict>

--- a/Apple/Xcode.pkg.recipe
+++ b/Apple/Xcode.pkg.recipe
@@ -44,9 +44,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Xcode.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/Xcode_unpack/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/Xcode_unpack/Xcode.app</string>
             </dict>
         </dict>
         <dict>

--- a/Apple/XcodeEdu.pkg.recipe
+++ b/Apple/XcodeEdu.pkg.recipe
@@ -63,9 +63,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/payload/Applications/%NAME%.app</string>
+                <string>%pkgroot%/payload/Applications/XcodeEdu.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/Xcode_unpack/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/Xcode_unpack/XcodeEdu.app</string>
             </dict>
         </dict>
         <dict>

--- a/Apple/XcodeEdu.pkg.recipe
+++ b/Apple/XcodeEdu.pkg.recipe
@@ -63,9 +63,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/payload/Applications/XcodeEdu.app</string>
+                <string>%pkgroot%/payload/Applications/Xcode.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/Xcode_unpack/XcodeEdu.app</string>
+                <string>%RECIPE_CACHE_DIR%/Xcode_unpack/Xcode.app</string>
             </dict>
         </dict>
         <dict>

--- a/Axure/AxureRP.pkg.recipe
+++ b/Axure/AxureRP.pkg.recipe
@@ -27,7 +27,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Axure RP %MAJOR_VERSION%.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>
@@ -57,9 +57,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Axure RP %MAJOR_VERSION%.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Axure RP %MAJOR_VERSION%.app</string>
             </dict>
         </dict>
         <dict>

--- a/Burn/Burn.pkg.recipe
+++ b/Burn/Burn.pkg.recipe
@@ -39,7 +39,7 @@
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/Burn/Burn.localized/Burn.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Burn.app</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>

--- a/CloudMounter/CloudMounter.pkg.recipe
+++ b/CloudMounter/CloudMounter.pkg.recipe
@@ -41,7 +41,7 @@
                 <key>source_path</key>
                 <string>%pathname%/CloudMounter.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/CloudMounter.app</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>

--- a/Dashlane/Dashlane.pkg.recipe
+++ b/Dashlane/Dashlane.pkg.recipe
@@ -25,7 +25,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Dashlane.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>
@@ -55,9 +55,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Dashlane.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Dashlane.app</string>
             </dict>
         </dict>
         <dict>

--- a/Digital Rebellion/PreferenceManager.pkg.recipe
+++ b/Digital Rebellion/PreferenceManager.pkg.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Preference Manager.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>
@@ -53,9 +53,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Preference Manager.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Preference Manager.app</string>
             </dict>
         </dict>
         <dict>

--- a/EIZO/ColorNavigatorNX.pkg.recipe
+++ b/EIZO/ColorNavigatorNX.pkg.recipe
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%destination_path%/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%destination_path%/Applications/ColorNavigator NX.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>

--- a/Elgato Systems GmbH/ElgatoVideoCapture.pkg.recipe
+++ b/Elgato Systems GmbH/ElgatoVideoCapture.pkg.recipe
@@ -38,9 +38,9 @@ package.</string>
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Elgato Video Capture.app</string>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Elgato Video Capture.app</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>

--- a/FSMonitor/FSMonitor.pkg.recipe
+++ b/FSMonitor/FSMonitor.pkg.recipe
@@ -48,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/FSMonitor.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>

--- a/Facebook/WorkplaceChat.download.recipe
+++ b/Facebook/WorkplaceChat.download.recipe
@@ -38,7 +38,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%filename%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/%filename%/Workplace Chat.app</string>
                 <key>requires</key>
                 <string>identifier "workplace-desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = V9WTTPBFK9</string>
             </dict>

--- a/FeltTip/SoundStudio.pkg.recipe
+++ b/FeltTip/SoundStudio.pkg.recipe
@@ -61,7 +61,7 @@
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Sound Studio 4.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Sound Studio 4.app</string>
             </dict>
         </dict>
         <dict>

--- a/Glyphs/Glyphs.pkg.recipe
+++ b/Glyphs/Glyphs.pkg.recipe
@@ -53,7 +53,7 @@
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Glyphs.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Glyphs.app</string>
             </dict>
         </dict>
         <dict>

--- a/HP/HPEasyAdmin.pkg.recipe
+++ b/HP/HPEasyAdmin.pkg.recipe
@@ -51,7 +51,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Applications/HP Easy Admin.app/Contents/Info.plist</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleIdentifier</key>

--- a/KompoZer/KompoZer.pkg.recipe
+++ b/KompoZer/KompoZer.pkg.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/KompoZer.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>
@@ -53,9 +53,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/KompoZer.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/KompoZer.app</string>
             </dict>
         </dict>
         <dict>

--- a/MediaArea/MediaInfo.pkg.recipe
+++ b/MediaArea/MediaInfo.pkg.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/MediaInfo.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>
@@ -53,9 +53,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/MediaInfo.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/MediaInfo.app</string>
             </dict>
         </dict>
         <dict>

--- a/Mindjet/MindjetMindManager.pkg.recipe
+++ b/Mindjet/MindjetMindManager.pkg.recipe
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Mindjet MindManager.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>
@@ -53,9 +53,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Mindjet MindManager.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Mindjet MindManager.app</string>
             </dict>
         </dict>
         <dict>

--- a/Novabench/Novabench.pkg.recipe
+++ b/Novabench/Novabench.pkg.recipe
@@ -25,7 +25,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Novabench.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>
@@ -55,9 +55,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Novabench.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Novabench.app</string>
             </dict>
         </dict>
         <dict>

--- a/Opera/Opera.pkg.recipe
+++ b/Opera/Opera.pkg.recipe
@@ -55,7 +55,7 @@
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Opera.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Opera.app</string>
             </dict>
         </dict>
         <dict>

--- a/OutWit Technologies/OutWitHub.download.recipe
+++ b/OutWit Technologies/OutWitHub.download.recipe
@@ -36,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/OutWit Hub.app</string>
 				<key>requirement</key>
                     <string>identifier "com.outwit.outwit-hub" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Q6W5GV5VY4</string>
 			</dict>

--- a/Ricoh/RicohThetaSC.download.recipe
+++ b/Ricoh/RicohThetaSC.download.recipe
@@ -36,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/RICOH THETA.app</string>
 				<key>requirement</key>
 				<string>identifier "com.ricoh.thetasphericalviewer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5KACUT3YX8"</string>
 			</dict>

--- a/SPEAR/SPEAR.pkg.recipe
+++ b/SPEAR/SPEAR.pkg.recipe
@@ -25,7 +25,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/SPEAR.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleVersion</key>
@@ -55,9 +55,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/SPEAR.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/SPEAR.app</string>
             </dict>
         </dict>
         <dict>

--- a/Sketch/Sketch.pkg.recipe
+++ b/Sketch/Sketch.pkg.recipe
@@ -66,7 +66,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Sketch.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>

--- a/Syncplicity/syncplicity.pkg.recipe
+++ b/Syncplicity/syncplicity.pkg.recipe
@@ -58,7 +58,7 @@
               <key>Arguments</key>
               <dict>
                   <key>input_plist_path</key>
-                  <string>%RECIPE_CACHE_DIR%/payload/Applications/%NAME%.app/Contents/Info.plist</string>
+                  <string>%RECIPE_CACHE_DIR%/payload/Applications/Syncplicity.app/Contents/Info.plist</string>
                   <key>plist_version_key</key>
                   <string>CFBundleVersion</string>
               </dict>

--- a/Tech Smith/Snagit2018.pkg.recipe
+++ b/Tech Smith/Snagit2018.pkg.recipe
@@ -24,7 +24,7 @@ need to be licensed outside of this.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Snagit 2018.app</string>
 				<key>requirement</key>
 				<string>identifier "com.TechSmith.Snagit2018" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
 			</dict>

--- a/Tony/Tony.pkg.recipe
+++ b/Tony/Tony.pkg.recipe
@@ -61,7 +61,7 @@
                 <key>source_path</key>
                 <string>%pathname%/Tony.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Tony.app</string>
             </dict>
         </dict>
         <dict>

--- a/Valve/steam.download.recipe
+++ b/Valve/steam.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Steam.app</string>
 				<key>requires</key>
                 <string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MXGJJ98X76)</string>
 			</dict>

--- a/Valve/steam.pkg.recipe
+++ b/Valve/steam.pkg.recipe
@@ -25,7 +25,7 @@
         <key>Arguments</key>
         <dict>
             <key>input_plist_path</key>
-            <string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+            <string>%pathname%/Steam.app/Contents/Info.plist</string>
             <key>plist_version_key</key>
             <string>CFBundleVersion</string>
         </dict>
@@ -50,9 +50,9 @@
         <key>Arguments</key>
         <dict>
             <key>source_path</key>
-            <string>%pathname%/%NAME%.app</string>
+            <string>%pathname%/Steam.app</string>
             <key>destination_path</key>
-            <string>%pkgroot%/Applications/%NAME%.app</string>
+            <string>%pkgroot%/Applications/Steam.app</string>
         </dict>
     </dict>
     <dict>

--- a/Visual Paradigm/VisualParadigmCE.pkg.recipe
+++ b/Visual Paradigm/VisualParadigmCE.pkg.recipe
@@ -48,9 +48,9 @@
         <key>Arguments</key>
         <dict>
             <key>source_path</key>
-            <string>%pathname%/%NAME%.app</string>
+            <string>%pathname%/Visual Paradigm.app</string>
             <key>destination_path</key>
-            <string>%pkgroot%/Applications/%NAME%.app</string>
+            <string>%pkgroot%/Applications/Visual Paradigm.app</string>
         </dict>
     </dict>
     <dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.