### PR TITLE
MirrorOp

### DIFF
--- a/MirrorOp/MirrorOp.download.recipe
+++ b/MirrorOp/MirrorOp.download.recipe
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest MirrorOp Mac Sender.</string>
+    <key>Identifier</key>
+    <string>com.github.moofit-recipes.download.MirrorOp</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>MirrorOp</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>http://mirrorop.com/downloads/MirrorOpSender_mac.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/MirrorOp.dmg/MirrorOp.app</string>
+                <key>requirement</key>
+                <string>identifier "com.MirrorOp.Vitali" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UWHQ4AWKZ8</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/MirrorOp/MirrorOp.pkg.recipe
+++ b/MirrorOp/MirrorOp.pkg.recipe
@@ -13,28 +13,10 @@
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.moofit-recipes.download.MirrorOp</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>http://mirrorop.com/downloads/MirrorOpSender_mac.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-            </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>AppDmgVersioner</string>
@@ -59,15 +41,15 @@
             </dict>
         </dict>
         <dict>
-        	<key>Processor</key>
-        	<string>Copier</string>
-        	<key>Arguments</key>
-        	<dict>
-        		<key>source_path</key>
-        		<string>%RECIPE_CACHE_DIR%/%NAME%/MirrorOp.dmg/MirrorOp.app</string>
-        		<key>destination_path</key>
-        		<string>%pkgroot%/Applications/MirrorOp.app</string>
-        	</dict>
+            <key>Processor</key>
+            <string>Copier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/MirrorOp.dmg/MirrorOp.app</string>
+                <key>destination_path</key>
+                <string>%pkgroot%/Applications/MirrorOp.app</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>
@@ -96,6 +78,18 @@
                         </dict>
                     </array>
                 </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%/</string>
+                    <string>%RECIPE_CACHE_DIR%/Pkg/</string>
+                </array>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
• Split out .pkg recipe into .download & .pkg recipes
• Added CodeSignatureVerifier to .download
• Set .download as ParentRecipe for .pkg
• Added PathDeleter to .pkg to tidy up

Once PR'd we'll have a .munki recipe which uses the .download as the ParentRecipe