### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Processors/PathCreator.py
+++ b/Processors/PathCreator.py
@@ -16,11 +16,10 @@
 """See docstring for PathCreator class"""
 
 from __future__ import absolute_import
+
 import os.path
-import shutil
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["PathCreator"]
 

--- a/Processors/PathCreator.py
+++ b/Processors/PathCreator.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for PathCreator class"""
 
+from __future__ import absolute_import
 import os.path
 import shutil
 

--- a/Processors/PkgSigner.py
+++ b/Processors/PkgSigner.py
@@ -29,10 +29,10 @@ __all__ = ["PkgSigner"]
 
 class PkgSigner(Processor):
     description = ( "Signs a package.",
-    				"WARNING: The keychain that contains the signing certificate and key",
-    				"MUST be unlocked. Run the productsign command once manually so that",
-    				"you can give it access to the correct key so that autopkg can run",
-    				"without manual intervention." )
+                    "WARNING: The keychain that contains the signing certificate and key",
+                    "MUST be unlocked. Run the productsign command once manually so that",
+                    "you can give it access to the correct key so that autopkg can run",
+                    "without manual intervention." )
     input_variables = {
         "pkg_path": {
             "required": True,
@@ -53,7 +53,7 @@ class PkgSigner(Processor):
 
     def main(self):
 
-    	# rename unsigned package so that we can slot the signed package into place
+        # rename unsigned package so that we can slot the signed package into place
         pkg_dir = os.path.dirname( self.env[ "pkg_path" ] )
         pkg_base_name = os.path.basename( self.env[ "pkg_path" ] )
         ( pkg_name_no_extension, pkg_extension ) = os.path.splitext( pkg_base_name )

--- a/Processors/PkgSigner.py
+++ b/Processors/PkgSigner.py
@@ -69,7 +69,7 @@ class PkgSigner(Processor):
 
         print(command_line_list)
 
-        # print command_line_list
+        # print(command_line_list)
         subprocess.call( command_line_list )
 
 
@@ -78,4 +78,3 @@ class PkgSigner(Processor):
 if __name__ == '__main__':
     processor = PkgSigner()
     processor.execute_shell()
-    

--- a/Processors/PkgSigner.py
+++ b/Processors/PkgSigner.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 import FoundationPlist
 import subprocess
 import os
@@ -65,7 +67,7 @@ class PkgSigner(Processor):
                               unsigned_pkg_path, \
                               self.env[ "pkg_path" ] ]
 
-        print command_line_list
+        print(command_line_list)
 
         # print command_line_list
         subprocess.call( command_line_list )

--- a/Processors/PkgSigner.py
+++ b/Processors/PkgSigner.py
@@ -15,14 +15,12 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
-from __future__ import print_function
-import FoundationPlist
-import subprocess
+from __future__ import absolute_import, print_function
+
 import os
+import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["PkgSigner"]
 

--- a/Processors/Rsync.py
+++ b/Processors/Rsync.py
@@ -12,6 +12,7 @@
 # specific processors.
 # pylint: disable=e1101,f0401
 
+from __future__ import absolute_import
 import subprocess
 
 from autopkglib import Processor, ProcessorError

--- a/Processors/Rsync.py
+++ b/Processors/Rsync.py
@@ -13,6 +13,7 @@
 # pylint: disable=e1101,f0401
 
 from __future__ import absolute_import
+
 import subprocess
 
 from autopkglib import Processor, ProcessorError

--- a/Processors/XcodeXIPUnpacker.py
+++ b/Processors/XcodeXIPUnpacker.py
@@ -20,6 +20,7 @@
 # pylint: disable=e1101,f0401
 
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import glob
 import os
@@ -135,7 +136,7 @@ class XcodeXIPUnpacker(Processor):
     # f.close()
     magic = self.seekread(f, length=4)
     if magic != 'pbzx':
-      raise "Error: Not a pbzx file"
+      raise ("Error: Not a pbzx file")
     # Read 8 bytes for initial flags
     flags = self.seekread(f, length=8)
     # Interpret the flags as a 64-bit big-endian unsigned int
@@ -176,7 +177,7 @@ class XcodeXIPUnpacker(Processor):
         xar_f.write(f_content)
         if tail != 'YZ':
           xar_f.close()
-          raise "Error: Footer is not xar file footer"
+          raise ("Error: Footer is not xar file footer")
     try:
       f.close()
       xar_f.close()

--- a/Processors/XcodeXIPUnpacker.py
+++ b/Processors/XcodeXIPUnpacker.py
@@ -21,13 +21,14 @@
 
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 import glob
 import os
 import shutil
 import struct
 import subprocess
 
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["XcodeXIPUnpacker"]
 
@@ -136,7 +137,7 @@ class XcodeXIPUnpacker(Processor):
     # f.close()
     magic = self.seekread(f, length=4)
     if magic != 'pbzx':
-      raise ("Error: Not a pbzx file")
+      raise ProcessorError("Error: Not a pbzx file")
     # Read 8 bytes for initial flags
     flags = self.seekread(f, length=8)
     # Interpret the flags as a 64-bit big-endian unsigned int
@@ -177,7 +178,7 @@ class XcodeXIPUnpacker(Processor):
         xar_f.write(f_content)
         if tail != 'YZ':
           xar_f.close()
-          raise ("Error: Footer is not xar file footer")
+          raise ProcessorError("Error: Footer is not xar file footer")
     try:
       f.close()
       xar_f.close()


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.