### PR TITLE
Add CodeSignatureVerifier processor

### DIFF
--- a/Syncplicity/Syncplicity.download.recipe
+++ b/Syncplicity/Syncplicity.download.recipe
@@ -32,6 +32,21 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authorities</key>
+                <array>
+                    <string>Developer ID Installer: Syncplicity, Inc. (9MAQ4GMJ3D)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Context: The [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Using-CodeSignatureVerification) processor ensures that the downloaded applications/packages are signed by the expected developer certificate. Although this is not a guarantee that the payload is trouble-free, it's a good indicator that the file you downloaded is the one you intended to download.