### PR TITLE
Update Adobe Remote Update Manager recipes

### DIFF
--- a/Adobe/RemoteUpdateManager.download.recipe
+++ b/Adobe/RemoteUpdateManager.download.recipe
@@ -12,7 +12,7 @@
         <key>NAME</key>
         <string>Adobe RemoteUpdateManager</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://s3.amazonaws.com/deploymenttools-prod/RemoteUpdateManager_mac.zip</string>
+        <string>https://deploymenttools-prod.s3.amazonaws.com/RUM/RemoteUpdateManager.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.1</string>

--- a/Adobe/RemoteUpdateManager.download.recipe
+++ b/Adobe/RemoteUpdateManager.download.recipe
@@ -25,8 +25,6 @@
             <dict>
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
-                <key>filename</key>
-				<string>RemoteUpdateManager_mac.zip</string>
             </dict>
         </dict>
         <dict>
@@ -35,22 +33,11 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/extract</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/extract/RemoteUpdateManager_mac/RemoteUpdateManager</string>
+                <string>%pathname%/RemoteUpdateManager</string>
                 <key>requirement</key>
                 <string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "JQ525L2MZD")</string>
             </dict>

--- a/Adobe/RemoteUpdateManager.pkg.recipe
+++ b/Adobe/RemoteUpdateManager.pkg.recipe
@@ -12,7 +12,7 @@
         <key>NAME</key>
         <string>Adobe RemoteUpdateManager</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://s3.amazonaws.com/deploymenttools-prod/RemoteUpdateManager_mac.zip</string>
+        <string>https://deploymenttools-prod.s3.amazonaws.com/RUM/RemoteUpdateManager.dmg</string>
         <key>IDENTIFIER</key>
         <string>com.adobe.RemoteUpdateManager</string>
         <key>VERSION</key>

--- a/Adobe/RemoteUpdateManager.pkg.recipe
+++ b/Adobe/RemoteUpdateManager.pkg.recipe
@@ -16,7 +16,7 @@
         <key>IDENTIFIER</key>
         <string>com.adobe.RemoteUpdateManager</string>
         <key>VERSION</key>
-        <string>2.3.0.4</string>
+        <string>2.4.0.3</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.1</string>
@@ -44,7 +44,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/extract/RemoteUpdateManager_mac/RemoteUpdateManager</string>
+                <string>%pathname%/RemoteUpdateManager</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/usr/local/bin/RemoteUpdateManager</string>
             </dict>


### PR DESCRIPTION
A new URL is available in the Admin Console that results in pulling a newer version of the RUM tool.