### PR TITLE
Update MirrorOp.download.recipe

### DIFF
--- a/MirrorOp/MirrorOp.download.recipe
+++ b/MirrorOp/MirrorOp.download.recipe
@@ -17,27 +17,36 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLDownloader</string>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                </dict>
+            </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://mirrorop.com/downloads/MirrorOpSender_mac.zip</string>
+                <string>https://www.barco.com/en/support/mirrorop/drivers</string>
+                <key>re_pattern</key>
+                <string>(Download\?FileNumber=R33050100\S*ShowDownloadPage=False)</string>
+                <key>result_output_var_name</key>
+                <string>match</string>
             </dict>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://www.barco.com/services/website/en/TdeFiles/%match%</string>
             </dict>
-        </dict>
-        <dict>
             <key>Processor</key>
-            <string>EndOfCheckPhase</string>
+            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Processor</key>
@@ -45,7 +54,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/MirrorOp.dmg/MirrorOp.app</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/MirrorOp.app</string>
                 <key>requirement</key>
                 <string>identifier "com.MirrorOp.Vitali" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UWHQ4AWKZ8</string>
             </dict>


### PR DESCRIPTION
Updated to use new URL from www.barco.com. Had to add a PathDeleter at the beginning to delete the recipe cache dir as Autopkg would error out during the URLDownloader with a curl error 22/HTTP 400 on subsequent runs if a DMG was previously downloaded.

Running curl against the source URL directly didn't generate those errors, even when overwriting a pre-existing output file, so I gave up and went for the sledgehammer option (PathDeleter). It's crude and means you get a 18MB download each time the recipe runs, but it works... Hopefully someone with more knowledge might find a curl option or something that means we don't have to do that. :-)

Fixes https://github.com/autopkg/moofit-recipes/issues/35