### PR TITLE
Make Dragonframe4 recipes more efficient

### DIFF
--- a/Dragonframe/Dragonframe4.download.recipe
+++ b/Dragonframe/Dragonframe4.download.recipe
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%-%version%.pkg</string>
+                <string>%NAME%.pkg</string>
                 <key>url</key>
                 <string>%url%</string>
             </dict>

--- a/Dragonframe/Dragonframe4.pkg.recipe
+++ b/Dragonframe/Dragonframe4.pkg.recipe
@@ -20,22 +20,9 @@ package</string>
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame4.pkg</string>
-                <key>source_path</key>
-                <string>%pathname%</string>
-                <key>overwrite</key>
-                <true/>
-            </dict>
-            <key>Processor</key>
-            <string>Copier</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/expanded</string>
                 <key>flat_pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame4.pkg</string>
+                <string>%pathname%</string>
             </dict>
             <key>Processor</key>
             <string>FlatPkgUnpacker</string>
@@ -51,27 +38,19 @@ package</string>
             <key>Processor</key>
             <string>PkgPayloadUnpacker</string>
         </dict>
-         <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/Applications/Dragonframe 4/Dragonframe 4.app/Contents/Info.plist</string>
-                <key>plist_version_key</key>
-                <string>CFBundleShortVersionString</string>
-            </dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-        </dict>
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/downloads/DragonFrame4.pkg</string>
-                </array>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/Applications/Dragonframe 4/Dragonframe 4.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                </dict>
             </dict>
             <key>Processor</key>
-            <string>PathDeleter</string>
+            <string>PlistReader</string>
         </dict>
         <dict>
             <key>Arguments</key>


### PR DESCRIPTION
There were a number of things that are done with the download & pkg recipes that wasn't as efficient as it might be that this addresses:

- Remove %version% from filename download. This was confusing because the pkg recipe copied the downloaded file back to the downloads directly but without the version number in order to be expanded to extract the version. This now avoids having to use Copier for this purpose.
- Use %pathname% in FltPkgUnpacker
- Remove PathDeleter since we don't need to remove that file anymore.
- Replace Versioner with PlistReader. While Dragonframe does not currently use LSMinimumSystemVersion for the minimum allowed macOS version, this change would allow any additional Info.plist keys to be collected, if needed in the future.

Once merged, I will update my Dragonframe4.munki recipe accordingly