### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/Adobe/PhoneGapDesktop.download.recipe
+++ b/Adobe/PhoneGapDesktop.download.recipe
@@ -47,7 +47,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/PhoneGapDesktop.dmg/PhoneGap.app</string>
-				<key>requires</key>
+				<key>requirement</key>
                 <string>identifier "com.electron.phonegap" and anchor apple generic and certificate leaf[subject.CN] = "Mac Developer: Herman Wong (M6QFED29S9)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
 			</dict>
 		</dict>

--- a/Autodesk/AutoCAD.download.recipe
+++ b/Autodesk/AutoCAD.download.recipe
@@ -33,7 +33,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%found_filename%/*.app</string>
-				<key>requires</key>
+				<key>requirement</key>
                 <string>identifier "com.autodesk.AutoCAD2021.installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XXKJ396S2Y</string>
 			</dict>
 		</dict>

--- a/Autodesk/Maya.download.recipe
+++ b/Autodesk/Maya.download.recipe
@@ -33,7 +33,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%found_filename%/*.app</string>
-				<key>requires</key>
+				<key>requirement</key>
                 <string>identifier "com.autodesk.desktop.delivery" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XXKJ396S2Y</string>
 			</dict>
 		</dict>

--- a/Autodesk/Mudbox.download.recipe
+++ b/Autodesk/Mudbox.download.recipe
@@ -33,7 +33,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%found_filename%/*.app</string>
-				<key>requires</key>
+				<key>requirement</key>
                 <string>identifier "com.autodesk.pcwsetup" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XXKJ396S2Y</string>
 			</dict>
 		</dict>

--- a/Facebook/WorkplaceChat.download.recipe
+++ b/Facebook/WorkplaceChat.download.recipe
@@ -39,7 +39,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/%filename%/Workplace Chat.app</string>
-                <key>requires</key>
+                <key>requirement</key>
                 <string>identifier "workplace-desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = V9WTTPBFK9</string>
             </dict>
         </dict>

--- a/Valve/steam.download.recipe
+++ b/Valve/steam.download.recipe
@@ -39,7 +39,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Steam.app</string>
-				<key>requires</key>
+				<key>requirement</key>
                 <string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MXGJJ98X76)</string>
 			</dict>
         </dict>

--- a/Wonderunit/Storyboarder.download.recipe
+++ b/Wonderunit/Storyboarder.download.recipe
@@ -50,7 +50,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/Storyboarder.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>identifier "com.wonderunit.storyboarder" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UVHK77PMAM</string>
             </dict>
         </dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.