### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Adapter/Adapter.pkg.recipe
+++ b/Adapter/Adapter.pkg.recipe
@@ -82,10 +82,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Amazon/KindleGen.pkg.recipe
+++ b/Amazon/KindleGen.pkg.recipe
@@ -91,10 +91,10 @@ a package at /usr/local/bin/</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%pkgroot%</string>
                     <key>id</key>

--- a/Apple/Xcode.pkg.recipe
+++ b/Apple/Xcode.pkg.recipe
@@ -80,9 +80,9 @@
                     <string>purge_ds_store</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                 </dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
             </dict>
         </dict>
         <dict>

--- a/Apple/XcodeEdu.pkg.recipe
+++ b/Apple/XcodeEdu.pkg.recipe
@@ -313,9 +313,9 @@ writelog "Script completed"</string>
                     <string>%pkgroot%/scripts</string>
                     <key>pkgroot</key>
                     <string>%pkgroot%/payload</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                 </dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
             </dict>
         </dict>
         <dict>

--- a/Autodesk/AutoCAD.pkg.recipe
+++ b/Autodesk/AutoCAD.pkg.recipe
@@ -175,10 +175,10 @@ fi</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%VERSION%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%VERSION%</string>
                     <key>id</key>
                     <string>com.autodesk.AutoCAD%VERSION%</string>
                     <key>options</key>

--- a/Autodesk/Maya.pkg.recipe
+++ b/Autodesk/Maya.pkg.recipe
@@ -175,10 +175,10 @@ fi</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%VERSION%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%VERSION%</string>
                     <key>id</key>
                     <string>com.autodesk.Maya%VERSION%</string>
                     <key>options</key>

--- a/Autodesk/Mudbox.pkg.recipe
+++ b/Autodesk/Mudbox.pkg.recipe
@@ -175,10 +175,10 @@ fi</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%VERSION%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%VERSION%</string>
                     <key>id</key>
                     <string>com.autodesk.Mudbox%VERSION%</string>
                     <key>options</key>

--- a/Autodesk/SketchBookPro.pkg.recipe
+++ b/Autodesk/SketchBookPro.pkg.recipe
@@ -175,10 +175,10 @@ fi</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%VERSION%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%VERSION%</string>
                     <key>id</key>
                     <string>com.autodesk.SketchBookPro%VERSION%</string>
                     <key>options</key>

--- a/Axure/AxureRP.pkg.recipe
+++ b/Axure/AxureRP.pkg.recipe
@@ -67,10 +67,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Barco/ClickShare.pkg.recipe
+++ b/Barco/ClickShare.pkg.recipe
@@ -95,10 +95,10 @@ fi</string>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>options</key>
                     <string>purge_ds_store</string>
                     <key>scripts</key>

--- a/Barco/MirrorOp.pkg.recipe
+++ b/Barco/MirrorOp.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Dashlane/Dashlane.pkg.recipe
+++ b/Dashlane/Dashlane.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Derivative/TouchDesigner.pkg.recipe
+++ b/Derivative/TouchDesigner.pkg.recipe
@@ -61,10 +61,10 @@
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                         <key>id</key>

--- a/EasyFind/EasyFind.pkg.recipe
+++ b/EasyFind/EasyFind.pkg.recipe
@@ -71,10 +71,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/FSMonitor/FSMonitor.pkg.recipe
+++ b/FSMonitor/FSMonitor.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/FeltTip/SoundStudio.pkg.recipe
+++ b/FeltTip/SoundStudio.pkg.recipe
@@ -69,10 +69,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Glyphs/Glyphs.pkg.recipe
+++ b/Glyphs/Glyphs.pkg.recipe
@@ -61,10 +61,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/HP/HPEasyAdmin.pkg.recipe
+++ b/HP/HPEasyAdmin.pkg.recipe
@@ -66,10 +66,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Keka/Keka.pkg.recipe
+++ b/Keka/Keka.pkg.recipe
@@ -58,10 +58,10 @@
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%</string>
                         <key>id</key>

--- a/KomodoEdit/KomodoEdit.pkg.recipe
+++ b/KomodoEdit/KomodoEdit.pkg.recipe
@@ -70,10 +70,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/KompoZer/KompoZer.pkg.recipe
+++ b/KompoZer/KompoZer.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/MediaArea/MediaInfo.pkg.recipe
+++ b/MediaArea/MediaInfo.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Mindjet/MindjetMindManager.pkg.recipe
+++ b/Mindjet/MindjetMindManager.pkg.recipe
@@ -63,10 +63,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Novabench/Novabench.pkg.recipe
+++ b/Novabench/Novabench.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Principle/principle.pkg.recipe
+++ b/Principle/principle.pkg.recipe
@@ -82,10 +82,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/SPEAR/SPEAR.pkg.recipe
+++ b/SPEAR/SPEAR.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Sketch/Sketch.pkg.recipe
+++ b/Sketch/Sketch.pkg.recipe
@@ -81,10 +81,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Sonos/SonosS2.pkg.recipe
+++ b/Sonos/SonosS2.pkg.recipe
@@ -56,10 +56,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/Syphon/SimpleClient.pkg.recipe
+++ b/Syphon/SimpleClient.pkg.recipe
@@ -72,10 +72,10 @@
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                         <key>id</key>

--- a/Syphon/SimpleServer.pkg.recipe
+++ b/Syphon/SimpleServer.pkg.recipe
@@ -72,10 +72,10 @@
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                         <key>id</key>

--- a/Syphon/SyphonRecorder.pkg.recipe
+++ b/Syphon/SyphonRecorder.pkg.recipe
@@ -61,10 +61,10 @@
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                         <key>id</key>

--- a/Tony/Tony.pkg.recipe
+++ b/Tony/Tony.pkg.recipe
@@ -69,10 +69,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).