### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Jamf/JamfConnectSyncLaunchAgent.pkg.recipe
+++ b/Jamf/JamfConnectSyncLaunchAgent.pkg.recipe
@@ -2,53 +2,51 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Transfers the package from the pre-downloaded DMG.</string>
-    <key>Identifier</key>
-    <string>com.github.moofit-recipes.pkg.JamfConnectSyncLaunchAgent</string>
-    <key>Input</key>
-    <dict>
-        <key>APP_FILENAME</key>
-        <string>Jamf Connect Sync LaunchAgent</string>
-        <key>BUNDLE_ID</key>
-        <string>com.jamf.connect.sync.launchagent</string>
-        <key>NAME</key>
-        <string>JamfConnectSyncLaunchAgent</string>
-        <key>version</key>
-        <string>1.0</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>1.0.0</string>
-    <key>ParentRecipe</key>
-    <string>com.github.yohan460-recipes.download.JamfConnect</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%/* Sync/Launch Agent/*ProRemoval.pkg</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: Orchard &amp; Grove Inc. (VRPY9KHGX6)</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCopier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_pkg</key>
-                <string>%pathname%/* Sync/Launch Agent/*ProRemoval.pkg</string>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-            </dict>
-        </dict>
-    </array>
+	<key>Description</key>
+	<string>Transfers the package from the pre-downloaded DMG.</string>
+	<key>Identifier</key>
+	<string>com.github.moofit-recipes.pkg.JamfConnectSyncLaunchAgent</string>
+	<key>Input</key>
+	<dict>
+		<key>APP_FILENAME</key>
+		<string>Jamf Connect Sync LaunchAgent</string>
+		<key>NAME</key>
+		<string>JamfConnectSyncLaunchAgent</string>
+		<key>version</key>
+		<string>1.0</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.yohan460-recipes.download.JamfConnect</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Orchard &amp; Grove Inc. (VRPY9KHGX6)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%/* Sync/Launch Agent/*ProRemoval.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%/* Sync/Launch Agent/*ProRemoval.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Zwift/Zwift.pkg.recipe
+++ b/Zwift/Zwift.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.moofit-recipes.pkg.Zwift</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.zwift.ZwiftLauncher</string>
 		<key>NAME</key>
 		<string>Zwift</string>
 	</dict>
@@ -20,15 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			 <key>Processor</key>
-			 <string>PkgCopier</string>
-			 <key>Arguments</key>
-			 <dict>
-					<key>source_pkg</key>
-					<string>%pathname%/ZwiftInstaller.pkg</string>
-					<key>pkg_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-			 </dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%/ZwiftInstaller.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ❌ Jamf/JamfConnectSyncLaunchAgent.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/moofit-recipes/Jamf/JamfConnectSyncLaunchAgent.pkg.recipe
Processing repos/moofit-recipes/Jamf/JamfConnectSyncLaunchAgent.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Jamf Connect Sync LaunchAgent.dmg',
           'url': 'https://files.jamfconnect.com/JamfConnect.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.JamfConnectSyncLaunchAgent/downloads/Jamf Connect Sync LaunchAgent.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.JamfConnectSyncLaunchAgent/downloads/Jamf '
                        'Connect Sync LaunchAgent.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Orchard & '
                                        'Grove Inc. (VRPY9KHGX6)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.JamfConnectSyncLaunchAgent/downloads/Jamf '
                         'Connect Sync LaunchAgent.dmg/* Sync/Launch '
                         'Agent/*ProRemoval.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.JamfConnectSyncLaunchAgent/downloads/Jamf Connect Sync LaunchAgent.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.JamfConnectSyncLaunchAgent/receipts/JamfConnectSyncLaunchAgent.pkg-receipt-20210213-230057.plist

The following recipes failed:
    repos/moofit-recipes/Jamf/JamfConnectSyncLaunchAgent.pkg.recipe
        Error in com.github.moofit-recipes.pkg.JamfConnectSyncLaunchAgent: Processor: CodeSignatureVerifier: Error: Error processing path '/private/tmp/dmg.E7otY9/* Sync/Launch Agent/*ProRemoval.pkg' with glob. 

Nothing downloaded, packaged or imported.
```

## ✅ Zwift/Zwift.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/moofit-recipes/Zwift/Zwift.pkg.recipe
Processing repos/moofit-recipes/Zwift/Zwift.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Zwift.dmg', 'url': 'https://zwift.com/download/mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/downloads/Zwift.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/downloads/Zwift.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Zwift, Inc '
                                        '(C2GM8Y9VFM)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/downloads/Zwift.dmg/ZwiftInstaller.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/downloads/Zwift.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "ZwiftInstaller.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2020-11-02 18:53:46 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Zwift, Inc (C2GM8Y9VFM)
CodeSignatureVerifier:        Expires: 2025-10-31 14:23:40 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            CA 41 04 B7 58 68 D5 9C FF 85 68 25 5C B3 12 E1 C2 5D A5 C2 F6 AF 
CodeSignatureVerifier:            E0 37 FB 80 9D 64 D0 04 06 5A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/downloads/Zwift.dmg/ZwiftInstaller.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/downloads/Zwift.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.Ey460E/ZwiftInstaller.pkg to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/payload',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/unpack/Zwift.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/unpack/Zwift.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/payload
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/payload/Zwift.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 1.0 in file ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/payload/Zwift.app/Contents/Info.plist
{'Output': {'version': '1.0'}}
PkgCopier
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/Zwift-1.0.pkg',
           'source_pkg': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/downloads/Zwift.dmg/ZwiftInstaller.pkg'}}
PkgCopier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/downloads/Zwift.dmg
PkgCopier: Copied /private/tmp/dmg.R3XSRq/ZwiftInstaller.pkg to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/Zwift-1.0.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/Zwift-1.0.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/Zwift-1.0.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/receipts/Zwift.pkg-receipt-20210213-230102.plist

The following packages were copied:
    Pkg Path                                                                                
    --------                                                                                
    ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.Zwift/Zwift-1.0.pkg  
```

