### PR TITLE
Add pkgroot to PathDeleter

### DIFF
--- a/Apple/Xcode.pkg.recipe
+++ b/Apple/Xcode.pkg.recipe
@@ -93,6 +93,7 @@
                 <key>path_list</key>
                 <array>
                     <string>%RECIPE_CACHE_DIR%/%NAME%_unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                 </array>
             </dict>
         </dict>


### PR DESCRIPTION
Add pkgroot to PathDeleter to clean up "temporary" file locations.

Xcode is now 30GB, this could be beneficial to clean up after each autopkg run.