### PR TITLE
Update and enhance AdobeRemoteUpdate recipes

### DIFF
--- a/Adobe/RemoteUpdateManager.download.recipe
+++ b/Adobe/RemoteUpdateManager.download.recipe
@@ -11,8 +11,6 @@
     <dict>
         <key>NAME</key>
         <string>Adobe RemoteUpdateManager</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://deploymenttools-prod.s3.amazonaws.com/RUM/RemoteUpdateManager.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.1</string>
@@ -24,7 +22,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
+                <string>https://deploymenttools.acp.adobeoobe.com/RUM/MacUniversal/RemoteUpdateManager.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Adobe/RemoteUpdateManager.pkg.recipe
+++ b/Adobe/RemoteUpdateManager.pkg.recipe
@@ -11,12 +11,8 @@
     <dict>
         <key>NAME</key>
         <string>Adobe RemoteUpdateManager</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://deploymenttools-prod.s3.amazonaws.com/RUM/RemoteUpdateManager.dmg</string>
         <key>IDENTIFIER</key>
         <string>com.adobe.RemoteUpdateManager</string>
-        <key>VERSION</key>
-        <string>2.4.0.3</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.1</string>
@@ -51,6 +47,19 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>file://%pkgroot%/usr/local/bin/RemoteUpdateManager</string>
+                <key>re_pattern</key>
+                <string>&lt;key&gt;CFBundleShortVersionString&lt;/key&gt;\s+&lt;string&gt;([\d.]+)</string>
+                <key>result_output_var_name</key>
+                <string>version</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
@@ -74,11 +83,9 @@
                     <key>options</key>
                     <string>purge_ds_store</string>
                     <key>pkgname</key>
-                    <string>%NAME%-%VERSION%</string>
+                    <string>%NAME%-%version%</string>
                     <key>pkgroot</key>
                     <string>%RECIPE_CACHE_DIR%/payload</string>
-                    <key>version</key>
-                    <string>%VERSION%</string>
                 </dict>
             </dict>
         </dict>


### PR DESCRIPTION
I've deliberately separated the commits for the two files in case you don't want one but want the other.

The current AdobeRemoteUpdate.download recipe does not download versions past 2.4.0.3. There is a new URL which downloads the executable, suitable for use with Intel and Apple Silicon. I've chosen to hardcode the new URL into the processor argument so that current users of the recipe will receive the new URL without having to update their overrides.

As well, the current AdobeRemoteUpdate.pkg recipe requires that the user specify the version number via an input variable. I devised a method to obtain that value automatically by searching the executable for text in an embedded plist that provides the version number. I also removed the redundant reference to `DOWNLOAD_URL` in the input variables (whether you accept my other change or not, the presence of this would supersede the value for `DOWNLOAD_URL` in the parent; it does not need to be there either way).