### PR TITLE
Replaced hardcoded "Docker" @ line 44 and 109 with %NAME% variable

### DIFF
--- a/Docker/DockerUniversal.pkg.recipe
+++ b/Docker/DockerUniversal.pkg.recipe
@@ -41,7 +41,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Docker-amd64-*.dmg</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%-amd64-*.dmg</string>
             </dict>
             <key>Processor</key>
             <string>FileFinder</string>
@@ -106,7 +106,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/Docker-arm64-*.dmg</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%-arm64-*.dmg</string>
             </dict>
             <key>Processor</key>
             <string>FileFinder</string>


### PR DESCRIPTION
We encountered an issue when we tried to override the %NAME% variable in the Docker Universal recipe, as it conflicts with the hardcoded filename.