### PR TITLE
Update ClickShare.download.recipe

### DIFF
--- a/Barco/ClickShare.download.recipe
+++ b/Barco/ClickShare.download.recipe
@@ -24,19 +24,29 @@
                 <true/>
                 <key>path_list</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.zip</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/downloadUrl.json</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
+            <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
+                <key>filename</key>
+                <string>downloadUrl.json</string>
                 <key>url</key>
-                <string>https://www.barco.com/en/clickshare/app</string>
-                <key>re_pattern</key>
-                <string>(Download\?FileNumber=R3306192\S*ShowDownloadPage=False)</string>
-                <key>result_output_var_name</key>
-                <string>match</string>
+                <string>https://www.barco.com/bin/barco/tde/downloadUrl.json?fileNumber=R3306192&amp;tdeType=3</string>
+            </dict>
+        </dict>
+         <dict>
+            <key>Processor</key>
+            <string>com.github.dataJAR-recipes.Shared Processors/JSONFileReader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>json_key</key>
+                <string>downloadUrl</string>
+                <key>json_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/downloadUrl.json</string>
             </dict>
         </dict>
         <dict>
@@ -47,7 +57,7 @@
                 <key>filename</key>
                 <string>%NAME%.zip</string>
                 <key>url</key>
-                <string>https://www.barco.com/services/website/en/TdeFiles/%match%</string>
+                <string>%json_value%</string>
             </dict>
         </dict>
 		<dict>
@@ -69,7 +79,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/*.dmg</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/*/*.dmg</string>
 			</dict>
 		</dict>
         <dict>


### PR DESCRIPTION
Hi, 

This PR has an updated pattern for FileFinder, as the dmg is now in folder.

-v out put from a successful run
```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/moofit-recipes/Barco/ClickShare.download.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/moofit-recipes/Barco/ClickShare.download.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/moofit-recipes/Barco/ClickShare.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.smithjw.processors/FriendlyPathDeleter
FriendlyPathDeleter: Path does not exist, skipping: /Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/downloads/ClickShare.zip
URLTextSearcher
URLTextSearcher: Found matching text (match): Download?FileNumber=R3306192&amp;TdeType=3&amp;MajorVersion=04&amp;MinorVersion=28&amp;PatchVersion=00&amp;BuildVersion=011&amp;ShowDownloadPage=False
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 27 Mar 2023 14:00:57 GMT
URLDownloader: Storing new ETag header: "0x8DB2ECBB088468E"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/downloads/ClickShare.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename ClickShare.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/downloads/ClickShare.zip to /Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/unpack
FileFinder
FileFinder: Found file match: '/Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/unpack/R3306192_45_ApplicationSw/ClickShare_Setup.dmg' from globbed '/Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/unpack/*/*.dmg'
FileFinder: Basename match: 'ClickShare_Setup.dmg'
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/unpack/R3306192_45_ApplicationSw/ClickShare_Setup.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.RK70hB/ClickShare.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.RK70hB/ClickShare.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.RK70hB/ClickShare.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/receipts/ClickShare.download-receipt-20230405-145228.plist

The following new items were downloaded:
    Download Path                                                                                             
    -------------                                                                                             
    /Users/paul/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ClickShare/downloads/ClickShare.zip 
```

Thanks