### PR TITLE
Fix Download issue for MirrorOp

### DIFF
--- a/Barco/MirrorOp.download.recipe
+++ b/Barco/MirrorOp.download.recipe
@@ -23,7 +23,7 @@
                 <key>fail_deleter_silently</key>
                 <true/>
                 <key>path_list</key>
-                <string>%RECIPE_CACHE_DIR%</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -31,7 +31,7 @@
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
-                <key>request_headers</key>
+                <!-- <key>request_headers</key>
                 <dict>
                     <key>Referer</key>
                     <string>https://www.barco.com/gb-en/support/mirrorop/drivers;auto</string>
@@ -53,7 +53,7 @@
                     <string>gzip, deflate, br</string>
                     <key>Connection</key>
                     <string>keep-alive</string>
-                </dict>
+                </dict> -->
                 <key>re_pattern</key>
                 <string>downloadUrl\":\"(.*)\",</string>
                 <key>result_output_var_name</key>
@@ -69,11 +69,11 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-                <key>request_headers</key>
+                <!-- <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15</string>
-                </dict>
+                </dict> -->
                 <key>url</key>
                 <string>%match%</string>
             </dict>

--- a/Barco/MirrorOp.pkg.recipe
+++ b/Barco/MirrorOp.pkg.recipe
@@ -19,65 +19,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>AppDmgVersioner</string>
+            <string>AppPkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/MirrorOp.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/package</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>Applications</key>
-                    <string>0775</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/MirrorOp.dmg/MirrorOp.app</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/Applications/MirrorOp.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>pkgdir</key>
-                    <string>%RECIPE_CACHE_DIR%</string>
-                    <key>id</key>
-                    <string>com.mirrop.macsender.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                    </array>
-                </dict>
+                <key>app_path</key>
+                <string>%pathname%/MirrorOp.app</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
The download issue is simply caused by this request header being included:
```xml
<key>Accept-Encoding</key>
<string>gzip, deflate, br</string>
```

That said, none of the recently added request headers seem to be required.  I've left them, just in case, but commented them out as it wasn't stated why they were added.

The issue described in 0f7bd7f is caused by the web server not accepting, or allowing, the etag `If-None-Match` and last modified `If-Modified-Since` checks.  If these are not included, then the web server will not return a 400.  Not quite sure why they're not supporting this as it literally should be saving them bandwidth...  Anyways, even if you set `CHECK_FILESIZE_ONLY` as `True` in the `URLDownloader` step, the parent class `URLGetter` still adds the etag and last modified headers to the `curl` command.  I'm not sure if this was an oversight or by design, but as far as I know, it hasn't affected anything else for all these years...  I'll probably submit a PR to the autopkg repo and see what they think.  If accepted, the `FriendlyPathDeleter` step could then be removed.  And then the `CHECK_FILESIZE_ONLY` option will actually work as intended.

Speaking of the `FriendlyPathDeleter` step, I also dialed back the heavy handed "sledgehammer" option and instead of deleting the entire directory, simply deleting the .dmg file itself as this is all that's actually required.  So, this will at least allow history and created .pkgs to remain and _those_ at least won't have to be re-created when they already exist.

Finally I greatly simplified the .pkg recipe.