### PR TITLE
FIx so that Overriding NAME does not break recipe

### DIFF
--- a/Final Draft 12/FinalDraft12.download.recipe.yaml
+++ b/Final Draft 12/FinalDraft12.download.recipe.yaml
@@ -27,14 +27,14 @@ Process:
   
   - Processor: CodeSignatureVerifier
     Arguments:
-      input_path: "%RECIPE_CACHE_DIR%/Final Draft 12/Final Draft 12.dmg/Final Draft 12.app"
+      input_path: "%RECIPE_CACHE_DIR%/%NAME%/Final Draft 12.dmg/Final Draft 12.app"
       requirement: anchor apple generic and identifier "com.finaldraft.finaldraft.v12" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7XUZ8R5736")
   
   - Processor: EndOfCheckPhase
 
   - Processor: PlistReader
     Arguments:
-      info_path: "%RECIPE_CACHE_DIR%/Final Draft 12/Final Draft 12.dmg/Final Draft 12.app"
+      info_path: "%RECIPE_CACHE_DIR%/%NAME%/Final Draft 12.dmg/Final Draft 12.app"
       plist_keys:
         CFBundleShortVersionString: version
         CFBundleIdentifier: bundleid


### PR DESCRIPTION
Overriding the NAME variable was causing the recipe to fail, as part of the path to the dmg was hard coded using the default NAME input.   This pull request resolves that issue.