### PR TITLE
New download URL for Sketch

### DIFF
--- a/Sketch/Sketch.pkg.recipe
+++ b/Sketch/Sketch.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Sketch</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://www.sketch.com/download/sketch.zip</string>
+        <string>https://download.sketch.com/sketch.zip</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>


### PR DESCRIPTION
The current download URL 404's and has moved.
This PR adds in the new download URL