### PR TITLE
Update TouchDesigner recipes

### DIFF
--- a/Derivative/TouchDesigner.download.recipe
+++ b/Derivative/TouchDesigner.download.recipe
@@ -11,7 +11,11 @@
             <key>NAME</key>
             <string>TouchDesigner</string>
             <key>DOWNLOAD_PAGE</key>
-            <string>https://derivative.ca/download</string>
+            <string>https://derivative.ca/download/release-download/39</string>
+            <key>USER_AGENT</key>
+            <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15</string>
+            <key>ARCH</key> <!-- either intel or arm64 -->
+            <string>intel</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.2.0</string>  
@@ -25,7 +29,12 @@
                     <key>url</key>
                     <string>%DOWNLOAD_PAGE%</string>
                     <key>re_pattern</key>
-                    <string>https://download.derivative.ca/TouchDesigner.[0-9]+.[a-zA-Z0-9]+.intel.dmg</string>
+                    <string>https://download.derivative.ca/TouchDesigner.[0-9]+.[a-zA-Z0-9]+.%ARCH%.dmg</string>
+                    <key>request_headers</key>
+                    <dict>
+                        <key>user-agent</key>
+                        <string>%USER_AGENT%</string>
+                    </dict>
                     <key>result_output_var_name</key>
                     <string>DOWNLOAD_URL</string>
                 </dict>

--- a/Derivative/TouchDesigner.pkg.recipe
+++ b/Derivative/TouchDesigner.pkg.recipe
@@ -64,7 +64,7 @@
                     <key>pkg_request</key>
                     <dict>
                         <key>pkgname</key>
-                        <string>%NAME%-%version%</string>
+                        <string>%NAME%-%ARCH%-%version%</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%/pkgroot</string>
                         <key>id</key>


### PR DESCRIPTION
Updated the download url and added a new input variable for ARCH. pkg recipe will now include the arch in pkg name. 