### PR TITLE
Add Architecture Support and CodeSignatureVerifier to ShutterEncoder

### DIFF
--- a/Shutter Encoder/ShutterEncoder.download.recipe
+++ b/Shutter Encoder/ShutterEncoder.download.recipe
@@ -3,7 +3,10 @@
 <plist version="1.0">
 <dict>
     <key>Identifier</key>
-    <string>com.github.moofit-recipes.download.ShutterEncoder</string>
+    <string>com.github.moofit-recipes.download.ShutterEncoder
+
+To Download the Intel version use "Mac 64bits" in the DOWNLOAD_TYPE variable
+To Download the Apple Silicon version use "Apple Silicon" in the DOWNLOAD_TYPE variable</string>
     <key>Description</key>
     <string>Downloads the latest version of Shutter Encoder</string>
     <key>Input</key>
@@ -13,7 +16,9 @@
         <key>DOWNLOAD_PAGE_URL</key>
         <string>https://www.shutterencoder.com</string>
         <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
+        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15'</string>
+        <key>DOWNLOAD_TYPE</key>
+        <string>Mac 64bits</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.1</string>
@@ -29,7 +34,7 @@
                 <key>result_output_var_name</key>
                 <string>url</string>
                 <key>re_pattern</key>
-                <string>Shutter Encoder .* Mac 64bits.pkg</string>
+                <string>Shutter Encoder .* %DOWNLOAD_TYPE%.pkg</string>
                 <key>re_flags</key>
                 <array>
                     <string>IGNORECASE</string>

--- a/Shutter Encoder/ShutterEncoder.download.recipe
+++ b/Shutter Encoder/ShutterEncoder.download.recipe
@@ -3,12 +3,12 @@
 <plist version="1.0">
 <dict>
     <key>Identifier</key>
-    <string>com.github.moofit-recipes.download.ShutterEncoder
+    <string>com.github.moofit-recipes.download.ShutterEncoder</string>
+    <key>Description</key>
+    <string>Downloads the latest version of Shutter Encoder
 
 To Download the Intel version use "Mac 64bits" in the DOWNLOAD_TYPE variable
 To Download the Apple Silicon version use "Apple Silicon" in the DOWNLOAD_TYPE variable</string>
-    <key>Description</key>
-    <string>Downloads the latest version of Shutter Encoder</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -71,6 +71,21 @@ To Download the Apple Silicon version use "Apple Silicon" in the DOWNLOAD_TYPE v
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Codebase Media UG (haftungsbeschrankt) (LZ28YRG3Q4)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Hi, Folks 

The PR adds support for downloading Intel and Apple Silicon architecture types, and adds in CodeSignatureVerifier to check the pkg.

Output from a successful -v Intel run
```
autopkg run -v ShutterEncoder.download.recipe
**load_recipe time: 0.00036774999171029776
Processing ShutterEncoder.download.recipe...
WARNING: ShutterEncoder.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): Shutter Encoder 18.0 Mac 64bits.pkg
com.github.homebysix.FindAndReplace/FindAndReplace
FindAndReplace: Replacing " " with "%20" in "Shutter Encoder 18.0 Mac 64bits.pkg".
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 26 Mar 2024 05:24:15 GMT
URLDownloader: Storing new ETag header: "7dc9f7f-61489804ac214"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/downloads/Shutter%20Encoder%2018.0%20Mac%2064bits.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Shutter%20Encoder%2018.0%20Mac%2064bits.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-03-26 05:09:31 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Codebase Media UG (haftungsbeschrankt) (LZ28YRG3Q4)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            94 87 A2 55 FA F5 37 46 F5 10 1D 60 DD 5E DD A8 A4 85 5F 28 CD 09 
CodeSignatureVerifier:            6D AE 8B 2B 67 8B E0 64 72 5E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/receipts/ShutterEncoder.download-receipt-20240408-095925.plist

The following new items were downloaded:
    Download Path                                                                                                                                     
    -------------                                                                                                                                     
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/downloads/Shutter%20Encoder%2018.0%20Mac%2064bits.pkg
```

Output from a successful -v Apple Silicon run
```
autopkg run -v ShutterEncoder.download.recipe
**load_recipe time: 0.00036429100146051496
Processing ShutterEncoder.download.recipe...
WARNING: ShutterEncoder.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): Shutter Encoder 18.0 Apple Silicon.pkg
com.github.homebysix.FindAndReplace/FindAndReplace
FindAndReplace: Replacing " " with "%20" in "Shutter Encoder 18.0 Apple Silicon.pkg".
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 26 Mar 2024 05:24:13 GMT
URLDownloader: Storing new ETag header: "7a53f26-61489802d8563"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/downloads/Shutter%20Encoder%2018.0%20Apple%20Silicon.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Shutter%20Encoder%2018.0%20Apple%20Silicon.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-03-26 05:07:50 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Codebase Media UG (haftungsbeschrankt) (LZ28YRG3Q4)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            94 87 A2 55 FA F5 37 46 F5 10 1D 60 DD 5E DD A8 A4 85 5F 28 CD 09 
CodeSignatureVerifier:            6D AE 8B 2B 67 8B E0 64 72 5E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/receipts/ShutterEncoder.download-receipt-20240408-095955.plist

The following new items were downloaded:
    Download Path                                                                                                                                        
    -------------                                                                                                                                        
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/downloads/Shutter%20Encoder%2018.0%20Apple%20Silicon.pkg
```