### PR TITLE
Fixed Recipes

### DIFF
--- a/Screaming Frog/ScreamingFrogSEOSpider-Universal.download.recipe.yaml
+++ b/Screaming Frog/ScreamingFrogSEOSpider-Universal.download.recipe.yaml
@@ -17,23 +17,6 @@ Process:
       filename: "ScreamingFrogSEOSpider-%INTEL_ARCH%.dmg"
       download_dir: "%RECIPE_CACHE_DIR%/Downloads"
 
-  - Processor: EndOfCheckPhase
-
-  - Processor: CodeSignatureVerifier
-    Arguments:
-      input_path: "%pathname%/Screaming Frog SEO Spider.app"
-      requirement: identifier "uk.co.screamingfrog.seo.spider" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CAHEVC3HZC
-
-  - Processor: PlistReader
-    Arguments:
-      info_path: "/Applications/Screaming Frog SEO Spider.app/Contents/Info.plist"
-      plist_keys: 
-        CFBundleShortVersionString: version
-        CFBundleIdentifier: bundle_id
-        CFBundleName: app_name
-
-  - Processor: EndOfCheckPhase
-
   - Processor: URLTextSearcher
     Arguments:
       url: "https://www.screamingfrog.co.uk/seo-spider/"
@@ -55,10 +38,8 @@ Process:
 
   - Processor: PlistReader
     Arguments:
-      info_path: "/Applications/Screaming Frog SEO Spider.app/Contents/Info.plist"
+      info_path: "%pathname%/Screaming Frog SEO Spider.app/Contents/Info.plist"
       plist_keys: 
         CFBundleShortVersionString: version
         CFBundleIdentifier: bundle_id
         CFBundleName: app_name
-
-  - Processor: EndOfCheckPhase

--- a/Screaming Frog/ScreamingFrogSEOSpider-Universal.pkg.recipe.yaml
+++ b/Screaming Frog/ScreamingFrogSEOSpider-Universal.pkg.recipe.yaml
@@ -133,7 +133,7 @@ Process:
       pkg_request:
         id: "%bundle_id%"
         options: purge_ds_store
-        pkgname: "ScreamingFrogSEOSpider-Universal-%version%"
+        pkgname: "%app_name%_Universal-%version%"
         pkgroot: "%RECIPE_CACHE_DIR%/universal/root"
         scripts: "%RECIPE_CACHE_DIR%/universal/scripts"
         version: "%version%"


### PR DESCRIPTION
- Corrected plist path in download recipe so that plist can be read
- removed duplicate processors
- Changed final PKGCreator to use app_name variable found in plst to ensure app name is correct