### PR TITLE
Add User-Agent to avoid Cloudflare blocks

### DIFF
--- a/Barco/ClickShare.download.recipe
+++ b/Barco/ClickShare.download.recipe
@@ -10,6 +10,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>ClickShare</string>
+		<key>USER_AGENT</key>
+		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
@@ -29,6 +31,11 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>request_headers</key>
+				<dict>
+					<key>User-Agent</key>
+					<string>%USER_AGENT%</string>
+				</dict>
 				<key>re_pattern</key>
 				<string>"downloadUrl":"(https://.+)"</string>
 				<key>result_output_var_name</key>


### PR DESCRIPTION
Currently Cloudflare is blocking access to https://www.barco.com/bin/barco/tde/downloadUrl.json?fileNumber=R3306192&tdeType=3. By adding a User-Agent, this allows the recipe to continue working.