### PR TITLE
Update MiroUniversal.download.recipe.yaml

### DIFF
--- a/Miro/MiroUniversal.download.recipe.yaml
+++ b/Miro/MiroUniversal.download.recipe.yaml
@@ -1,7 +1,7 @@
 Identifier: com.github.moofit-recipes.download.MiroUniversal
 Input:
-  AMD64_URL: https://desktop.miro.com/platforms/darwin/Miro.dmg
-  ARM64_URL: https://desktop.miro.com/platforms/darwin-arm64/Miro.dmg
+  AMD64_URL: https://desktop.miro.com/platforms/darwin/Install-Miro.dmg
+  ARM64_URL: https://desktop.miro.com/platforms/darwin-arm64/Install-Miro.dmg
   BUNDLE_ID: com.electron.realtimeboard
   NAME: Miro
 Process:


### PR DESCRIPTION
Updated urls

unable to curl urls from main download page so we'll stick to using direct urls in this recipe