### PR TITLE
Deprecate Isadora recipes

### DIFF
--- a/Troikatronix/Isadora.download.recipe
+++ b/Troikatronix/Isadora.download.recipe
@@ -22,9 +22,18 @@
 		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Isadora 4 recipes in dataJAR-recipes. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the non-functional Isadora recipes in this repo in favor of the ones in dataJAR-recipes, which are still functional.