### PR TITLE
Deprecate KindleGen recipes

### DIFF
--- a/Amazon/KindleGen.download.recipe
+++ b/Amazon/KindleGen.download.recipe
@@ -19,9 +19,18 @@ Zip file)</string>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>KindleGen is no longer available for download (https://www.amazon.com/b?node=23972728011&ref_=cs_fdm_1000765211-23972728011). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
KindleGen is no longer available for download: https://www.amazon.com/b?node=23972728011&ref_=cs_fdm_1000765211-23972728011

This PR deprecates the KindleGen recipes.