### PR TITLE
Deprecate Telegram recipes

### DIFF
--- a/Telegram/Telegram.download.recipe.yaml
+++ b/Telegram/Telegram.download.recipe.yaml
@@ -6,6 +6,9 @@ Input:
 
 MinimumVersion: '2.3'
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: "Consider switching to the Telegram recipes in the tallfunnyjew-recipes repo. This recipe is deprecated and will be removed in the future."
 
   - Processor: URLDownloader
     Arguments:


### PR DESCRIPTION
This PR deprecates the redundant Telegram recipes in this repo, and points users to working equivalents in the tallfunnyjew-recipes repo.
