### PR TITLE
Deprecate Yo recipes

### DIFF
--- a/moof IT/yo.download.recipe
+++ b/moof IT/yo.download.recipe
@@ -25,6 +25,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Yo recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-functional Yo recipes in this repo, and points users to working equivalents in my homebysix-recipes repo.
