### PR TITLE
Fix RODE Connect recipes

### DIFF
--- a/RODE/RODEConnect.download.recipe.yaml
+++ b/RODE/RODEConnect.download.recipe.yaml
@@ -4,24 +4,12 @@ MinimumVersion: "2.3"
 
 Input:
   NAME: RODE Connect
-  URL: https://rode.com/en/software/rodeconnect#module_17
 
 Process:
 
-  - Processor: URLTextSearcher
-    Arguments:
-      re_pattern: https.+?RODE Connect macOS.+?zip
-      url: "%URL%"
-
-  - Processor: com.github.homebysix.FindAndReplace/FindAndReplace
-    Arguments:
-      find: " "
-      input_string: "%match%"
-      replace: "%20"
-
   - Processor: URLDownloader
     Arguments:
-      url: "%output_string%"
+      url: "https://update.rode.com/connect/RODE_Connect_MACOS.zip"
       filename: "%NAME%.zip"
 
   - Processor: EndOfCheckPhase
@@ -34,16 +22,14 @@ Process:
     Comment: Unzipping for code signature verification. Path must be deleted afterwards to prevent unzipping over existing version.
     Processor: Unarchiver
 
-  - Processor: PkgCopier
+  - Processor: FileFinder
     Arguments:
-      pkg_path: "%RECIPE_CACHE_DIR%/%NAME%.pkg"
-      source_pkg: "%RECIPE_CACHE_DIR%/unzip/*/RODE Connect.pkg"
+      pattern: "%RECIPE_CACHE_DIR%/unzip/*.pkg"
 
   - Processor: CodeSignatureVerifier
     Arguments:
-      input_path: "%RECIPE_CACHE_DIR%/%NAME%.pkg"
+      input_path: "%found_filename%"
       expected_authority_names: 
        - "Developer ID Installer: FREEDMAN ELECTRONICS PTY LTD (Z9T72PWTJA)"
        - Developer ID Certification Authority
        - Apple Root CA
-

--- a/RODE/RODEConnect.pkg.recipe.yaml
+++ b/RODE/RODEConnect.pkg.recipe.yaml
@@ -9,7 +9,7 @@ Process:
   - Processor: FlatPkgUnpacker
     Arguments:
       destination_path: "%RECIPE_CACHE_DIR%/unpack"
-      flat_pkg_path: "%RECIPE_CACHE_DIR%/%NAME%.pkg"
+      flat_pkg_path: "%found_filename%"
       purge_destination: false
   - Processor: PkgPayloadUnpacker
     Arguments:
@@ -22,4 +22,4 @@ Process:
   - Processor: PkgCopier
     Arguments:
       pkg_path: "%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg"
-      source_pkg: "%RECIPE_CACHE_DIR%/%NAME%.pkg"
+      source_pkg: "%found_filename%"


### PR DESCRIPTION
This PR updates the RODE Connect recipes with a new download URL, and simplifies the process of finding, verifying, and copying the resulting pkg.

Verbose download recipe run output:

```
% autopkg run -vvq 'RODE/RODEConnect.download.recipe.yaml'
Processing RODE/RODEConnect.download.recipe.yaml...
WARNING: RODE/RODEConnect.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'RODE Connect.zip',
           'url': 'https://update.rode.com/connect/RODE_Connect_MACOS.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/downloads/RODE Connect.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/downloads/RODE '
                        'Connect.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_format': 'zip',
           'archive_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/downloads/RODE '
                           'Connect.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/unzip',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/downloads/RODE Connect.zip to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/unzip
{'Output': {}}
FileFinder
{'Input': {'pattern': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/unzip/*.pkg'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/unzip/RØDE Connect (1.3.43).pkg' from globbed '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/unzip/*.pkg'
FileFinder: Basename match: 'RØDE Connect (1.3.43).pkg'
{'Output': {'found_basename': 'RØDE Connect (1.3.43).pkg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/unzip/RØDE '
                              'Connect (1.3.43).pkg'}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: FREEDMAN '
                                        'ELECTRONICS PTY LTD (Z9T72PWTJA)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/unzip/RØDE '
                         'Connect (1.3.43).pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "RØDE Connect (1.3.43).pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-10-25 06:51:36 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: FREEDMAN ELECTRONICS PTY LTD (Z9T72PWTJA)
CodeSignatureVerifier:        Expires: 2026-02-24 02:14:29 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E8 3D 6E DE A8 9E E3 57 21 2F 30 D5 D7 65 A0 21 E7 9A 8B 85 BD B3
CodeSignatureVerifier:            36 31 36 8C B9 77 43 DB F2 27
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.RODEConnect/receipts/RODEConnect.download.recipe-receipt-20241227-101723.plist

Nothing downloaded, packaged or imported.
```

Verbose pkg recipe run output:

```
% autopkg run -vvq 'RODE/RODEConnect.pkg.recipe.yaml'
Processing RODE/RODEConnect.pkg.recipe.yaml...
WARNING: RODE/RODEConnect.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'RODE Connect.zip',
           'url': 'https://update.rode.com/connect/RODE_Connect_MACOS.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 30 Oct 2024 23:45:26 GMT
URLDownloader: Storing new ETag header: "a732963db08f54ce584d47936547e5c4-1"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/downloads/RODE Connect.zip
{'Output': {'download_changed': True,
            'etag': '"a732963db08f54ce584d47936547e5c4-1"',
            'last_modified': 'Wed, 30 Oct 2024 23:45:26 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/downloads/RODE '
                        'Connect.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/downloads/RODE '
                                                                        'Connect.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_format': 'zip',
           'archive_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/downloads/RODE '
                           'Connect.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/downloads/RODE Connect.zip to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip
{'Output': {}}
FileFinder
{'Input': {'pattern': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/*.pkg'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/RØDE Connect (1.3.43).pkg' from globbed '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/*.pkg'
FileFinder: Basename match: 'RØDE Connect (1.3.43).pkg'
{'Output': {'found_basename': 'RØDE Connect (1.3.43).pkg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/RØDE '
                              'Connect (1.3.43).pkg'}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: FREEDMAN '
                                        'ELECTRONICS PTY LTD (Z9T72PWTJA)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/RØDE '
                         'Connect (1.3.43).pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "RØDE Connect (1.3.43).pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-10-25 06:51:36 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: FREEDMAN ELECTRONICS PTY LTD (Z9T72PWTJA)
CodeSignatureVerifier:        Expires: 2026-02-24 02:14:29 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E8 3D 6E DE A8 9E E3 57 21 2F 30 D5 D7 65 A0 21 E7 9A 8B 85 BD B3
CodeSignatureVerifier:            36 31 36 8C B9 77 43 DB F2 27
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/RØDE '
                            'Connect (1.3.43).pkg',
           'purge_destination': False}}
FlatPkgUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/RØDE Connect (1.3.43).pkg to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unpack',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unpack/RodeConnect.pkg/Payload',
           'purge_destination': False}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unpack/RodeConnect.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unpack
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unpack/Applications/RODE '
                               'Connect.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 1.3.43 in file ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unpack/Applications/RODE Connect.app/Contents/Info.plist
{'Output': {'version': '1.3.43'}}
PkgCopier
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/RODE '
                       'Connect-1.3.43.pkg',
           'source_pkg': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/RØDE '
                         'Connect (1.3.43).pkg'}}
PkgCopier: Copied ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/unzip/RØDE Connect (1.3.43).pkg to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/RODE Connect-1.3.43.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/RODE '
                                                               'Connect-1.3.43.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/RODE '
                        'Connect-1.3.43.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/receipts/RODEConnect.pkg.recipe-receipt-20241227-101805.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/downloads/RODE Connect.zip

The following packages were copied:
    Pkg Path
    --------
    ~/Library/AutoPkg/Cache/com.github.moofit-recipes.pkg.RODEConnect/RODE Connect-1.3.43.pkg
```
