### PR TITLE
Fix dataJAR Notifier recipes and add code signature verification

### DIFF
--- a/moof IT/Notifier.download.recipe
+++ b/moof IT/Notifier.download.recipe
@@ -40,6 +40,21 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Data JAR Ltd (82K2XFN8L6)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/moof IT/Notifier.download.recipe
+++ b/moof IT/Notifier.download.recipe
@@ -10,12 +10,8 @@
     <dict>
         <key>NAME</key>
         <string>Notifier</string>
-		<key>VERSION</key>
-		<string></string>
         <key>INCLUDE_PRERELEASES</key>
         <string></string>
-        <key>GITHUB_REPO</key>
-        <string>dataJAR/Notifier</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.5.0</string>
@@ -27,9 +23,9 @@
             <key>Arguments</key>
             <dict>
                 <key>asset_regex</key>
-                <string>.*Notifier-%VERSION%.pkg</string>
+                <string>Notifier.*\.pkg</string>
                 <key>github_repo</key>
-                <string>%GITHUB_REPO%</string>
+                <string>dataJAR/Notifier</string>
                 <key>include_prereleases</key>
                 <string>%INCLUDE_PRERELEASES%</string>
                 <key>sort_by_highest_tag_names</key>


### PR DESCRIPTION
This PR updates the asset regex used to obtain dataJAR Notifier downloads from GitHub releases. It also adds code signature verification.

Verbose recipe run output:

```
% autopkg run -vvq 'moof IT/Notifier.download.recipe'
Processing moof IT/Notifier.download.recipe...
WARNING: moof IT/Notifier.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Notifier.*\\.pkg',
           'github_repo': 'dataJAR/Notifier',
           'include_prereleases': '',
           'sort_by_highest_tag_names': 'true'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Notifier.*\.pkg' among asset(s): Notifier-3.1.pkg
GitHubReleasesInfoProvider: Selected asset 'Notifier-3.1.pkg' from release 'Notifier'
{'Output': {'asset_created_at': '2024-10-21T14:20:58Z',
            'asset_url': 'https://api.github.com/repos/jamf/Notifier/releases/assets/200656303',
            'release_notes': "## What's Changed\r\n"
                             '- Banner notifications can now have buttons '
                             'added, the same as alerts.\r\n'
                             '\r\n'
                             '\r\n'
                             '**Full Changelog**: '
                             'https://github.com/dataJAR/Notifier/compare/3.0...3.1',
            'url': 'https://github.com/jamf/Notifier/releases/download/3.1/Notifier-3.1.pkg',
            'version': '3.1'}}
URLDownloader
{'Input': {'url': 'https://github.com/jamf/Notifier/releases/download/3.1/Notifier-3.1.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 21 Oct 2024 14:21:00 GMT
URLDownloader: Storing new ETag header: "0x8DCF1DB9667F6CF"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.Notifier/downloads/Notifier-3.1.pkg
{'Output': {'download_changed': True,
            'etag': '"0x8DCF1DB9667F6CF"',
            'last_modified': 'Mon, 21 Oct 2024 14:21:00 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.Notifier/downloads/Notifier-3.1.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.Notifier/downloads/Notifier-3.1.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Data JAR Ltd '
                                        '(82K2XFN8L6)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.Notifier/downloads/Notifier-3.1.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Notifier-3.1.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-10-18 14:20:32 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Data JAR Ltd (82K2XFN8L6)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            90 BF D8 5E 2C BE 1A A1 0E 59 93 D9 47 1D CF 38 C5 1F EE C2 AC BC
CodeSignatureVerifier:            5F D4 04 9C EF 81 6C E5 A9 6A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.Notifier/receipts/Notifier.download-receipt-20241227-100610.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.Notifier/downloads/Notifier-3.1.pkg
```

