### PR TITLE
Fix MIDIControlCenter recipes

### DIFF
--- a/Arturia/MIDIControlCenter.download.recipe
+++ b/Arturia/MIDIControlCenter.download.recipe
@@ -11,11 +11,9 @@
         <key>NAME</key>
         <string>MIDI Control Center</string>
         <key>CHECK_PAGE_URL</key>
-        <string>https://www.arturia.com/support/updates&amp;manuals/</string>
+        <string>https://www.arturia.com/api/resources?slugs=mccu&amp;types=soft</string>
         <key>CHECK_PAGE_PATTERN</key>
-        <string>http:\/\/downloads\.arturia\.com\/extra\/mcc\/MIDI_Control_Center_.*.pkg</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
+        <string>"(https://dl\.arturia\.net/products/mccu/soft/MIDI_Control_Center[\d_]+\.pkg)"</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.1</string>
@@ -30,27 +28,13 @@
                 <string>%CHECK_PAGE_URL%</string>
                 <key>re_pattern</key>
                 <string>%CHECK_PAGE_PATTERN%</string>
-                <key>re_flags</key>
-                <array>
-                    <string>IGNORECASE</string>
-                </array>
-                <key>request_headers</key>
-                <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
-                </dict>
                 <key>result_output_var_name</key>
-                <string>download_url</string>
+                <string>url</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%download_url%</string>
-            </dict>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
This PR updates the URL and pattern used to download the Arturia MIDI Control Center installer.

Verbose recipe run output:

```
% autopkg run -vvq 'Arturia/MIDIControlCenter.download.recipe'
Processing Arturia/MIDIControlCenter.download.recipe...
WARNING: Arturia/MIDIControlCenter.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '"(https://dl\\.arturia\\.net/products/mccu/soft/MIDI_Control_Center[\\d_]+\\.pkg)"',
           'result_output_var_name': 'url',
           'url': 'https://www.arturia.com/api/resources?slugs=mccu&types=soft'}}
URLTextSearcher: Found matching text (url): https://dl.arturia.net/products/mccu/soft/MIDI_Control_Center__1_18_2_6.pkg
{'Output': {'url': 'https://dl.arturia.net/products/mccu/soft/MIDI_Control_Center__1_18_2_6.pkg'}}
URLDownloader
{'Input': {'url': 'https://dl.arturia.net/products/mccu/soft/MIDI_Control_Center__1_18_2_6.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 19 Dec 2024 09:21:47 GMT
URLDownloader: Storing new ETag header: "1fed7cb5d3a1ce680e19094fb6588814-2"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.MIDIControlCenter/downloads/MIDI_Control_Center__1_18_2_6.pkg
{'Output': {'download_changed': True,
            'etag': '"1fed7cb5d3a1ce680e19094fb6588814-2"',
            'last_modified': 'Thu, 19 Dec 2024 09:21:47 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.MIDIControlCenter/downloads/MIDI_Control_Center__1_18_2_6.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.MIDIControlCenter/downloads/MIDI_Control_Center__1_18_2_6.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Arturia '
                                        '(T53ZHSF36C)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.MIDIControlCenter/downloads/MIDI_Control_Center__1_18_2_6.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "MIDI_Control_Center__1_18_2_6.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-19 08:43:58 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Arturia (T53ZHSF36C)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            74 B0 00 63 A0 CD 0E 3C 48 0D 19 96 2F E3 E9 16 CA 2D A4 E3 9E D3
CodeSignatureVerifier:            63 E2 0B 3C CC 8C 13 5B 53 66
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.MIDIControlCenter/receipts/MIDIControlCenter.download-receipt-20241227-100118.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.MIDIControlCenter/downloads/MIDI_Control_Center__1_18_2_6.pkg
```
