### PR TITLE
Deprecate DEPNotify recipes

### DIFF
--- a/Orchard and Grove/DEPNotify.download.recipe
+++ b/Orchard and Grove/DEPNotify.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the DEPNotify recipes in the rderewianko-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the DEPNotify recipes in this repo, which pull from a URL that appears to be offline. The deprecation warning points users to working alternatives in the rderewianko-recipes repo.
