### PR TITLE
Update moof.swiftDialog.download.recipe.yaml

### DIFF
--- a/swiftDialog/moof.swiftDialog.download.recipe.yaml
+++ b/swiftDialog/moof.swiftDialog.download.recipe.yaml
@@ -9,7 +9,7 @@ Process:
   - Processor: GitHubReleasesInfoProvider
     Arguments:
       github_repo: 'bartreardon/swiftDialog'
-      asset_regex: '.*\.pkg'
+      asset_regex: '.*2\.5\.4-4793\.pkg'
 
   - Processor: URLDownloader
 


### PR DESCRIPTION
Setting a specific version to the recipe to ensure versions are checked before being released.