### PR TITLE
Add code signature verification for SimpleApps recipes

### DIFF
--- a/Syphon/SimpleApps.download.recipe
+++ b/Syphon/SimpleApps.download.recipe
@@ -49,6 +49,28 @@
                     <string>%RECIPE_CACHE_DIR%/unpack</string>
                 </dict>
             </dict>
+            <dict>
+                <key>Processor</key>
+                <string>CodeSignatureVerifier</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>input_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack/Syphon Simple Apps/Simple Client.app</string>
+                    <key>requirement</key>
+                    <string>anchor apple generic and identifier "info.v002.syphon.Simple-Client" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SWFQ99ZP9J)</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>CodeSignatureVerifier</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>input_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpack/Syphon Simple Apps/Simple Server.app</string>
+                    <key>requirement</key>
+                    <string>anchor apple generic and identifier "info.v002.syphon.Simple-Server" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SWFQ99ZP9J)</string>
+                </dict>
+            </dict>
         </array>
     </dict>
 </plist>


### PR DESCRIPTION
This PR adds code signature verification to the SimpleApps recipes, including both the Simple Client and Simple Server apps.

Here's the CodeSignatureVerifier section of the verbose recipe run output:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.simpleapps/unpack/Syphon Simple Apps/Simple Client.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.simpleapps/unpack/Syphon Simple Apps/Simple Client.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.simpleapps/unpack/Syphon Simple Apps/Simple Client.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.simpleapps/unpack/Syphon Simple Apps/Simple Server.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.simpleapps/unpack/Syphon Simple Apps/Simple Server.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.moofit-recipes.download.simpleapps/unpack/Syphon Simple Apps/Simple Server.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```
