### PR TITLE
Add Architecture Support to ShutterEncoder.download.recipe

### DIFF
--- a/Barco/MirrorOp.download.recipe
+++ b/Barco/MirrorOp.download.recipe
@@ -31,29 +31,32 @@
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
-                <!-- <key>request_headers</key>
+                <key>curl_opts</key>
+                <array>
+                    <string>--cookie-jar</string>
+                    <string>%RECIPE_CACHE_DIR%/cookies.txt</string>
+                    <string>--cookie</string>
+                    <string>%RECIPE_CACHE_DIR%/cookies.txt</string>
+                </array>
+                <key>request_headers</key>
                 <dict>
-                    <key>Referer</key>
-                    <string>https://www.barco.com/gb-en/support/mirrorop/drivers;auto</string>
                     <key>user-agent</key>
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15</string>
-                    <key>Host</key>
-                    <string>www.barco.com</string>
                     <key>Accept</key>
-                    <string>*/*</string>
+                    <string>text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</string>
                     <key>Sec-Fetch-Site</key>
-                    <string>same-origin</string>
+                    <string>none</string>
                     <key>Sec-Fetch-Dest</key>
-                    <string>empty</string>
+                    <string>document</string>
                     <key>Accept-Language</key>
                     <string>en-GB,en;q=0.9</string>
-                    <key>Sec-Fetch-Mode</key>
-                    <string>cors</string>
+                    <key>Priority</key>
+                    <string>u=0, i</string>
                     <key>Accept-Encoding</key>
                     <string>gzip, deflate, br</string>
-                    <key>Connection</key>
-                    <string>keep-alive</string>
-                </dict> -->
+                    <key>Sec-Fetch-Mode</key>
+                    <string>navigate</string>
+                </dict>
                 <key>re_pattern</key>
                 <string>downloadUrl\":\"(.*)\",</string>
                 <key>result_output_var_name</key>
@@ -69,13 +72,18 @@
             <dict>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-                <!-- <key>request_headers</key>
+                <key>url</key>
+                <string>%match%</string>
+                <key>curl_opts</key>
+                <array>
+                    <string>--cookie</string>
+                    <string>%RECIPE_CACHE_DIR%/cookies.txt</string>
+                </array>
+                <key>request_headers</key>
                 <dict>
                     <key>user-agent</key>
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15</string>
-                </dict> -->
-                <key>url</key>
-                <string>%match%</string>
+                </dict>
             </dict>
         </dict>
         <dict>

--- a/Shutter Encoder/ShutterEncoder.download.recipe
+++ b/Shutter Encoder/ShutterEncoder.download.recipe
@@ -5,13 +5,18 @@
     <key>Identifier</key>
     <string>com.github.moofit-recipes.download.ShutterEncoder</string>
     <key>Description</key>
-    <string>Downloads the latest version of Shutter Encoder</string>
+    <string>Downloads the latest version of Shutter Encoder
+
+To download Apple Silicon use: "Apple Silicon" in the Apple Silicon variable
+To download Intel use: "Mac 64bits" in the DOWNLOAD_ARCH variable</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>Shutter Encoder</string>
         <key>DOWNLOAD_PAGE_URL</key>
         <string>https://www.shutterencoder.com</string>
+        <key>DOWNLOAD_ARCH</key>
+        <string>Mac 64bits</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
@@ -29,7 +34,7 @@
                 <key>result_output_var_name</key>
                 <string>url</string>
                 <key>re_pattern</key>
-                <string>Shutter Encoder .* Mac 64bits.pkg</string>
+                <string>Shutter Encoder .* %DOWNLOAD_ARCH%.pkg</string>
                 <key>re_flags</key>
                 <array>
                     <string>IGNORECASE</string>


### PR DESCRIPTION
Hi, folks.

This PR adds support for downloading architecture specific versions.

Output from -v runs
```
Shutter Encoder % autopkg run -v ShutterEncoder.download.recipe
**load_recipe time: 0.00041391700506210327
Processing ShutterEncoder.download.recipe...
WARNING: ShutterEncoder.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): Shutter Encoder 18.7 Apple Silicon.pkg
com.github.homebysix.FindAndReplace/FindAndReplace
FindAndReplace: Replacing " " with "%20" in "Shutter Encoder 18.7 Apple Silicon.pkg".
URLDownloader
URLDownloader: Storing new Last-Modified header: Sun, 29 Dec 2024 14:15:25 GMT
URLDownloader: Storing new ETag header: "64566af-62a6953c42fea"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/downloads/Shutter Encoder.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Shutter Encoder.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-29 14:08:49 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Codebase Media UG (haftungsbeschrankt) (LZ28YRG3Q4)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            94 87 A2 55 FA F5 37 46 F5 10 1D 60 DD 5E DD A8 A4 85 5F 28 CD 09 
CodeSignatureVerifier:            6D AE 8B 2B 67 8B E0 64 72 5E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/receipts/ShutterEncoder.download-receipt-20250205-104801.plist

The following new items were downloaded:
    Download Path                                                                                                             
    -------------                                                                                                             
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/downloads/Shutter Encoder.pkg
```

```
autopkg run -v ShutterEncoder.download.recipe
**load_recipe time: 0.0004182920019957237
Processing ShutterEncoder.download.recipe...
WARNING: ShutterEncoder.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): Shutter Encoder 18.7 Mac 64bits.pkg
com.github.homebysix.FindAndReplace/FindAndReplace
FindAndReplace: Replacing " " with "%20" in "Shutter Encoder 18.7 Mac 64bits.pkg".
URLDownloader
URLDownloader: Storing new Last-Modified header: Sun, 29 Dec 2024 14:15:28 GMT
URLDownloader: Storing new ETag header: "6732600-62a6953f225e6"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/downloads/Shutter Encoder.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Shutter Encoder.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-29 11:34:34 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Codebase Media UG (haftungsbeschrankt) (LZ28YRG3Q4)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            94 87 A2 55 FA F5 37 46 F5 10 1D 60 DD 5E DD A8 A4 85 5F 28 CD 09 
CodeSignatureVerifier:            6D AE 8B 2B 67 8B E0 64 72 5E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/receipts/ShutterEncoder.download-receipt-20250205-105048.plist

The following new items were downloaded:
    Download Path                                                                                                             
    -------------                                                                                                             
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.moofit-recipes.download.ShutterEncoder/downloads/Shutter Encoder.pkg
```