### PR TITLE
Fix unescaped ampersand in KindleGen recipe

### DIFF
--- a/Amazon/KindleGen.download.recipe
+++ b/Amazon/KindleGen.download.recipe
@@ -28,7 +28,7 @@ Zip file)</string>
             <key>Arguments</key>
             <dict>
                 <key>warning_message</key>
-                <string>KindleGen is no longer available for download (https://www.amazon.com/b?node=23972728011&ref_=cs_fdm_1000765211-23972728011). This recipe is deprecated and will be removed in the future.</string>
+                <string>KindleGen is no longer available for download (https://www.amazon.com/b?node=23972728011&amp;ref_=cs_fdm_1000765211-23972728011). This recipe is deprecated and will be removed in the future.</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Resolves unescaped ampersand introduced in the KindleGen deprecation message [here](https://github.com/autopkg/moofit-recipes/commit/bd11751e1f75b5b15c5fe50e9133c0fc18458517#commitcomment-154224787).