### PR TITLE
Update ReadWrite.download.recipe.yaml with new Sparkle feed

### DIFF
--- a/TextHelp/ReadWrite.download.recipe.yaml
+++ b/TextHelp/ReadWrite.download.recipe.yaml
@@ -10,7 +10,7 @@ Process:
 
   - Processor: SparkleUpdateInfoProvider
     Arguments:
-      appcast_url: https://readwrite.texthelp.com/rw7mac/updatesp/appcast.xml
+      appcast_url: https://fastdownloads2.texthelp.com/readwritemac7/updates/live/appcast.xml
 
   - Processor: URLDownloader
     Arguments:


### PR DESCRIPTION
Sparkle feed address has changed since version 7.2.16 (to https://fastdownloads2.texthelp.com/readwritemac7/updates/live/appcast.xml)