### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Amazon/KindleGen.pkg.recipe
+++ b/Amazon/KindleGen.pkg.recipe
@@ -14,7 +14,7 @@ a package at /usr/local/bin/</string>
         <key>CHECK_PAGE_URL</key>
         <string>https://www.amazon.com/gp/feature.html?docId=1000765211</string>
         <key>DOWNLOAD_PAGE_URL</key>
-        <string>http://kindlegen.s3.amazonaws.com</string>
+        <string>https://kindlegen.s3.amazonaws.com</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>

--- a/Autodesk/Meshmixer.pkg.recipe
+++ b/Autodesk/Meshmixer.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Meshmixer</string>
         <key>SEARCH_URL</key>
-        <string>http://www.meshmixer.com/download.html</string>
+        <string>https://www.meshmixer.com/download.html</string>
         <key>SEARCH_PATTERN</key>
         <string>(?P&lt;url&gt;http://www.meshmixer.com/downloads/Autodesk_Meshmixer_v[A-Za-z0-9_.]+_MacOS\.pkg)</string>
     </dict>

--- a/SPEAR/SPEAR.pkg.recipe
+++ b/SPEAR/SPEAR.pkg.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>SPEAR</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.klingbeil.com/spear/downloads/files/SPEAR_latest.dmg</string>
+        <string>https://www.klingbeil.com/spear/downloads/files/SPEAR_latest.dmg</string>
     </dict>
     <key>ParentRecipe</key>
     <string>com.github.hansen-m.download.SPEAR</string>

--- a/Syphon/SyphonRecorder.download.recipe
+++ b/Syphon/SyphonRecorder.download.recipe
@@ -11,7 +11,7 @@
             <key>NAME</key>
             <string>Syphon Recorder</string>
             <key>DOWNLOAD_URL</key>
-            <string>http://syphon.v002.info/downloads/Syphon%20Recorder.zip</string>
+            <string>https://syphon.v002.info/downloads/Syphon%20Recorder.zip</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.2.0</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._